### PR TITLE
Add Ruby 4.0 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
+        ruby: ["3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.4.0] - 2026-01-06
+
+- Add Ruby 4.0 compatibility
+
 ## [0.3.2] - 2025-12-10
 
 - Fix truncation logic in OpenAiTokenizer could lead to string parsing fails

--- a/discourse_ai-tokenizers.gemspec
+++ b/discourse_ai-tokenizers.gemspec
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib vendor]
 
   spec.add_dependency "activesupport", ">= 6.0"
-  spec.add_dependency "tiktoken_ruby", "~> 0.0.11.1"
-  spec.add_dependency "tokenizers", "~> 0.5.4"
+  spec.add_dependency "tiktoken_ruby", "~> 0.0.15"
+  spec.add_dependency "tokenizers", "~> 0.6.3"
 
-  spec.add_development_dependency "rubocop-discourse", "= 3.8.1"
+  spec.add_development_dependency "rubocop-discourse", "~> 3.8"
   spec.add_development_dependency "syntax_tree", "~> 6.2.0"
 end

--- a/lib/discourse_ai/tokenizers/version.rb
+++ b/lib/discourse_ai/tokenizers/version.rb
@@ -2,6 +2,6 @@
 
 module DiscourseAi
   module Tokenizers
-    VERSION = "0.3.2"
+    VERSION = "0.4"
   end
 end


### PR DESCRIPTION
## Summary
- Add Ruby 4.0 to CI test matrix (drop Ruby 3.2)
- Update dependencies for Ruby 4.0 compatibility
- Bump version to 0.4.0

## Test plan
- [x] All tests pass on Ruby 4.0